### PR TITLE
add TCNnet in dsad.py

### DIFF
--- a/deepod/models/_local_test_.py
+++ b/deepod/models/_local_test_.py
@@ -17,15 +17,21 @@ if __name__ == '__main__':
     test_file = '../../data/omi-1/omi-1_test.csv'
     train_df = pd.read_csv(train_file, sep=',', index_col=0)
     test_df = pd.read_csv(test_file, index_col=0)
-    y = test_df['label'].values
+    y_test = test_df['label'].values
+    y_train = train_df['label'].values
     train_df, test_df = train_df.drop('label', axis=1), test_df.drop('label', axis=1)
-    x = train_df.values
+    x_train = train_df.values
     x_test = test_df.values
 
-    # anom_id = np.where(y==1)[0]
-    # known_anom_id = np.random.choice(anom_id, 30)
-    # y_semi = np.zeros_like(y)
-    # y_semi[known_anom_id] = 1
+    n = len(x_test)
+    x_dsad_train = x_test[:int(n*0.8)]
+    y_dsad_train = y_test[:int(n*0.8)]
+
+    x_val = x_test[int(n*0.8):]
+    y_val = y_test[int(n*0.8):]
+
+
+    # y_semi[normal_id] = 1
 
     # clf = DevNet(device='cpu')
     # clf.fit(x, y_semi)
@@ -36,10 +42,19 @@ if __name__ == '__main__':
     # auc = roc_auc_score(y_score=scores, y_true=y)
     # print(auc)
 
-    clf = DeepSVDD(data_type='ts', stride=50, seq_len=100, epochs=20,
-                   device='cpu', network='TCN')
-    clf.fit(x)
-    scores = clf.decision_function(x_test)
+    # clf = DeepSVDD(data_type='ts', stride=50, seq_len=100, epochs=20,
+    #                device='cpu', network='TCN')
+    # clf.fit(x_dsad_train)
+    # scores = clf.decision_function(x_val)
+    #
+    # adj_eval_info = cal_metrics(y_val, scores, pa=True)
+    # print(adj_eval_info)
 
-    adj_eval_info = cal_metrics(y, scores, pa=True)
+    clf = DeepSAD(data_type='ts', stride=50, seq_len=100, epochs=20,
+                   device='cpu', network='TCN')
+    clf.fit(x_dsad_train, y_dsad_train)
+    print(f"x_test shape={x_val.shape}")
+    scores = clf.decision_function(x_val)
+
+    adj_eval_info = cal_metrics(y_val, scores, pa=True)
     print(adj_eval_info)

--- a/deepod/models/dsvdd.py
+++ b/deepod/models/dsvdd.py
@@ -110,7 +110,7 @@ class DeepSVDD(BaseDeepAD):
                 n_hidden=self.hidden_dims,
                 n_output=self.rep_dim,
                 activation=self.act
-            )
+            ).to(self.device)
         else:
             raise NotImplementedError('Not supported network structures')
 

--- a/deepod/test/test_dsvdd.py
+++ b/deepod/test/test_dsvdd.py
@@ -38,8 +38,8 @@ class TestDeepSVDD(unittest.TestCase):
             contamination=self.contamination, random_state=42
         )
 
-        train_file = 'data/omi-1/omi-1_train.csv'
-        test_file = 'data/omi-1/omi-1_test.csv'
+        train_file = '../../data/omi-1/omi-1_train.csv'
+        test_file = '../../data/omi-1/omi-1_test.csv'
         train_df = pd.read_csv(train_file, sep=',', index_col=0)
         test_df = pd.read_csv(test_file, index_col=0)
         y = test_df['label'].values
@@ -76,6 +76,7 @@ class TestDeepSVDD(unittest.TestCase):
         assert_equal(pred_scores2.shape[0], self.Xts_test.shape[0])
 
         # check performance
+        print(roc_auc_score(self.y_test, pred_scores))
         assert (roc_auc_score(self.y_test, pred_scores) >= self.roc_floor)
         adj_eval_info = cal_metrics(self.yts_test, pred_scores2, pa=True)
         assert (adj_eval_info[2] >= self.ts_f1_floor)


### PR DESCRIPTION
Hi ~
I adapt TCNnet to DeepSAD model by:
- preprocessing `y` in method `fit()` in `base_model.py`, to be consistent with the labels required by DeepSAD. In more detail: `-1` represents known anomalies, and `0` represents unlabeled data.
- adding `TCNnet` in the method `__init__()` in `dsad.py`
- modifying `training_forward()` in `dsad.py`, that is, we consider a window to be anomalous if the number of `-1` in the window exceeds half the window length, else we consider the window to be unlabeled

However, when I try to test TCNnet in `test_dsad.py`, I see that `roc_auc_score(self.y_test, pred_scores) >= self.roc_floor` is not satisfied (roc_auc_score(self.y_test, pred_scores)=0.7), does this mean the model is not performing well?

looking forward to your reply.
